### PR TITLE
Fix Azure Static Web Apps workflow output directory

### DIFF
--- a/.github/workflows/azure-static-web-apps-icy-hill-08e03e110.yml
+++ b/.github/workflows/azure-static-web-apps-icy-hill-08e03e110.yml
@@ -34,7 +34,10 @@ jobs:
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
           app_location: "/" # App source code path
           api_location: "" # Api source code path - optional
-          output_location: "dist/sample" # Built app content directory - optional
+          # Angular 20 outputs the production build to the `browser` folder
+          # inside `dist/<project>`. Point the workflow to that directory so
+          # the Static Web Apps action uploads the correct files.
+          output_location: "dist/sample/browser" # Built app content directory
           ###### End of Repository/Build Configurations ######
 
   close_pull_request_job:


### PR DESCRIPTION
## Summary
- fix the output_location in the Azure Static Web Apps workflow

## Testing
- `npx ng test --watch=false` *(fails: No binary for Chrome browser on your platform)*
- `npx ng build`


------
https://chatgpt.com/codex/tasks/task_e_6874edf0b5ac8329a6bb2048b2d40976