### PR TITLE
Fix Azure build job

### DIFF
--- a/.github/workflows/azure-static-web-apps-icy-hill-08e03e110.yml
+++ b/.github/workflows/azure-static-web-apps-icy-hill-08e03e110.yml
@@ -38,6 +38,8 @@ jobs:
           # inside `dist/<project>`. Point the workflow to that directory so
           # the Static Web Apps action uploads the correct files.
           output_location: "dist/sample/browser" # Built app content directory
+          # Specify a Node.js version supported by Angular 20
+          node_version: "20"
           ###### End of Repository/Build Configurations ######
 
   close_pull_request_job:


### PR DESCRIPTION
## Summary
- tweak Azure Static Web Apps deploy workflow
- specify Node.js 20 for Angular 20 build

## Testing
- `npm test` *(fails: No binary for Chrome browser)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6874f4414e208329a70033bd3bb000ed