### PR TITLE
Fix node version for static web apps build

### DIFF
--- a/.github/workflows/azure-static-web-apps-icy-hill-08e03e110.yml
+++ b/.github/workflows/azure-static-web-apps-icy-hill-08e03e110.yml
@@ -38,8 +38,6 @@ jobs:
           # inside `dist/<project>`. Point the workflow to that directory so
           # the Static Web Apps action uploads the correct files.
           output_location: "dist/sample/browser" # Built app content directory
-          # Specify a Node.js version supported by Angular 20
-          node_version: "20"
           ###### End of Repository/Build Configurations ######
 
   close_pull_request_job:

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "watch": "ng build --watch --configuration development",
     "test": "ng test"
   },
+  "engines": {
+    "node": ">=20.19.0"
+  },
   "prettier": {
     "overrides": [
       {


### PR DESCRIPTION
## Summary
- add engines field to specify node version
- clean up workflow

## Testing
- `npm test` *(fails: No Chrome binary available)*

------
https://chatgpt.com/codex/tasks/task_e_6875125f6f488329b93c6e72b0a8a10e